### PR TITLE
Fix version conflicts caused by PR#37

### DIFF
--- a/CommunicationAPI/CommunicationAPI.csproj
+++ b/CommunicationAPI/CommunicationAPI.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="5.1.316" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Contracts/Contracts.csproj
+++ b/Contracts/Contracts.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="5.1.316" />
   </ItemGroup>
 
 </Project>

--- a/TinyURLStatefulService/TinyURLStatefulService.csproj
+++ b/TinyURLStatefulService/TinyURLStatefulService.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="5.1.316" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.ServiceFabric.Services from 4.1.417 to 5.1.316. [(PR#37)](https://github.com/adityastic/TinyURL-Service-Fabric/pull/37).
Hope this fix can help you.

Best regards,
sucrose